### PR TITLE
add missing item_assets check + remove mlm:name unique requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased](https://github.com/crim-ca/mlm-extension/tree/main)
 
 ### Added
-- n/a
+- Add the missing JSON schema `item_assets` definition under a Collection to ensure compatibility with
+  the [Item Assets](https://github.com/stac-extensions/item-assets) extension, as mentioned this specification.
 
 ### Changed
 - n/a
@@ -17,7 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - n/a
 
 ### Removed
-- n/a
+- Field `mlm:name` requirement to be unique. There is no way to guarantee this from a single Item's definition
+  and their JSON schema validation. For uniqueness requirement, users should instead rely on the `id` property  
+  of the Item, which is ensured to be unique under the corresponding Collection, since it would not be retrievable
+  otherwise (i.e.: `collections/{collectionID}/items/{itemID}`).
 
 ### Fixed
 - n/a

--- a/README.md
+++ b/README.md
@@ -65,12 +65,14 @@ The fields in the table below can be used in these parts of STAC documents:
 - [ ] Catalogs
 - [x] Collections
 - [x] Item Properties (incl. Summaries in Collections)
-- [x] Assets (for both Collections and Items, incl. Item Asset Definitions in Collections, except `mlm:name`)
+- [x] Assets (for both Collections and Items, incl. [Item-Assets][item-assets] definitions in Collections)
 - [ ] Links
+
+[item-assets]: https://github.com/stac-extensions/item-assets
 
 | Field Name                  | Type                                                          | Description                                                                                                                                                                                                                                                                                 |
 |-----------------------------|---------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| mlm:name                    | string                                                        | **REQUIRED** A unique name for the model. This can include, but must be distinct, from simply naming the model architecture. If there is a publication or other published work related to the model, use the official name of the model.                                                    |
+| mlm:name                    | string                                                        | **REQUIRED** A name for the model. This can include, but must be distinct, from simply naming the model architecture. If there is a publication or other published work related to the model, use the official name of the model.                                                    |
 | mlm:architecture            | [Model Architecture](#model-architecture) string              | **REQUIRED** A generic and well established architecture name of the model.                                                                                                                                                                                                                 | 
 | mlm:tasks                   | \[[Task Enum](#task-enum)]                                    | **REQUIRED** Specifies the Machine Learning tasks for which the model can be used for. If multi-tasks outputs are provided by distinct model heads, specify all available tasks under the main properties and specify respective tasks in each [Model Output Object](#model-output-object). |
 | mlm:framework               | string                                                        | Framework used to train the model (ex: PyTorch, TensorFlow).                                                                                                                                                                                                                   |

--- a/json-schema/schema.json
+++ b/json-schema/schema.json
@@ -78,6 +78,12 @@
               "additionalProperties": {
                 "$ref": "#/$defs/fields"
               }
+            },
+            "item_assets": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/$defs/fields"
+              }
             }
           }
         },


### PR DESCRIPTION
## Description

### Added
- Add the missing JSON schema `item_assets` definition under a Collection to ensure compatibility with
  the [Item Assets](https://github.com/stac-extensions/item-assets) extension, as mentioned this specification.

### Removed
- Field `mlm:name` requirement to be unique. There is no way to guarantee this from a single Item's definition
  and their JSON schema validation. For uniqueness requirement, users should instead rely on the `id` property  
  of the Item, which is ensured to be unique under the corresponding Collection, since it would not be retrievable
  otherwise (i.e.: `collections/{collectionID}/items/{itemID}`).


## Related Issue

n/a

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] :books: Examples, docs, tutorials or dependencies update;
- [x] :wrench: Bug fix (non-breaking change which fixes an issue);
- [x] :clinking_glasses: Improvement (non-breaking change which improves an existing feature);
- [ ] :rocket: New feature (non-breaking change which adds functionality);
- [ ] :boom: Breaking change (fix or feature that would cause existing functionality to change);
- [ ] :closed_lock_with_key: Security fix.

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`CONTRIBUTING.md`](../CONTRIBUTING.md) guide;
- [x] I've updated the code style using `make codestyle`;
- [x] I've written tests for all new methods and classes that I created;
- [x] I've written the docstring in `Google` format for all the methods and classes that I used.
