### PR TITLE
use `glob_exclude` new feature for `bump-my-version`

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -55,14 +55,25 @@ toml = ["tomli (>=1.1.0)"]
 yaml = ["PyYAML"]
 
 [[package]]
+name = "bracex"
+version = "2.4"
+description = "Bash style brace expander."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "bracex-2.4-py3-none-any.whl", hash = "sha256:efdc71eff95eaff5e0f8cfebe7d01adf2c8637c8c92edaf63ef348c241a82418"},
+    {file = "bracex-2.4.tar.gz", hash = "sha256:a27eaf1df42cf561fed58b7a8f3fdf129d1ea16a81e1fadd1d17989bc6384beb"},
+]
+
+[[package]]
 name = "bump-my-version"
-version = "0.20.2"
+version = "0.21.0"
 description = "Version bump your Python project"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "bump_my_version-0.20.2-py3-none-any.whl", hash = "sha256:71a641ca40bcc795fbbb72a69b366ac9f45d990a5be32d2419cb1a89d9cf6bd3"},
-    {file = "bump_my_version-0.20.2.tar.gz", hash = "sha256:63357ec65543b566eaf6fef4691b94c3032a19463428f11bf5601f9f668d59ce"},
+    {file = "bump_my_version-0.21.0-py3-none-any.whl", hash = "sha256:a614d8176b5ac0e644239c9a8a246b696d316f68406fd78b8486a9e13fc93266"},
+    {file = "bump_my_version-0.21.0.tar.gz", hash = "sha256:c3f1a31e32345679b517cbba99a0875457ee45d7ba6189fcd2a74d3ddae41515"},
 ]
 
 [package.dependencies]
@@ -73,6 +84,7 @@ questionary = "*"
 rich = "*"
 rich-click = "*"
 tomlkit = "*"
+wcmatch = ">=8.5.1"
 
 [package.extras]
 dev = ["generate-changelog (>=0.7.6)", "git-fame (>=1.12.2)", "pip-tools", "pre-commit"]
@@ -1660,6 +1672,20 @@ docs = ["furo (>=2023.7.26)", "proselint (>=0.13)", "sphinx (>=7.1.2,!=7.3)", "s
 test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess (>=1)", "flaky (>=3.7)", "packaging (>=23.1)", "pytest (>=7.4)", "pytest-env (>=0.8.2)", "pytest-freezer (>=0.4.8)", "pytest-mock (>=3.11.1)", "pytest-randomly (>=3.12)", "pytest-timeout (>=2.1)", "setuptools (>=68)", "time-machine (>=2.10)"]
 
 [[package]]
+name = "wcmatch"
+version = "8.5.1"
+description = "Wildcard/glob file name matcher."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "wcmatch-8.5.1-py3-none-any.whl", hash = "sha256:24c19cedc92bc9c9e27f39db4e1824d72f95bd2cea32b254a47a45b1a1b227ed"},
+    {file = "wcmatch-8.5.1.tar.gz", hash = "sha256:c0088c7f6426cf6bf27e530e2b7b734031905f7e490475fd83c7c5008ab581b3"},
+]
+
+[package.dependencies]
+bracex = ">=2.1.1"
+
+[[package]]
 name = "wcwidth"
 version = "0.2.13"
 description = "Measures the displayed width of unicode strings in a terminal"
@@ -1673,4 +1699,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "1b99245b4f3a59a9cf8568091386e65262d4315bce093950fdbea90e77dac407"
+content-hash = "b9560ed9b80a10ce6662457ee244700c3b2dea37f549f9427fe9ac0deeed0d7e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ pytest-click = "^1.1.0"
 pytest-pikachu = "^1.0.0"
 coverage = "^7.3.0"
 ruff = "^0.2.2"
-bump-my-version = "^0.20.2"
+bump-my-version = "^0.21"
 
 [tool.bumpversion]
 current_version = "1.1.0"
@@ -104,16 +104,49 @@ message = "Bump version: {current_version} → {new_version}"
 
 [[tool.bumpversion.files]]
 glob = "**/*.json"
+glob_exclude = [
+  ".git/**",
+  "**/__pycache__/**",
+  ".mypy_cache/**",
+  ".tox/**",
+  ".venv/**",
+  "_build/**",
+  "build/**",
+  "dist/**",
+  "node_modules/**",
+]
 search = "https://crim-ca.github.io/mlm-extension/v{current_version}/schema.json"
 replace = "https://crim-ca.github.io/mlm-extension/v{new_version}/schema.json"
 
 [[tool.bumpversion.files]]
 glob = "**/*.md"
+glob_exclude = [
+  ".git/**",
+  "**/__pycache__/**",
+  ".mypy_cache/**",
+  ".tox/**",
+  ".venv/**",
+  "_build/**",
+  "build/**",
+  "dist/**",
+  "node_modules/**",
+]
 search = "https://crim-ca.github.io/mlm-extension/v{current_version}/schema.json"
 replace = "https://crim-ca.github.io/mlm-extension/v{new_version}/schema.json"
 
 [[tool.bumpversion.files]]
 glob = "**/*.py"
+glob_exclude = [
+  ".git/**",
+  "**/__pycache__/**",
+  ".mypy_cache/**",
+  ".tox/**",
+  ".venv/**",
+  "_build/**",
+  "build/**",
+  "dist/**",
+  "node_modules/**",
+]
 search = "https://crim-ca.github.io/mlm-extension/v{current_version}/schema.json"
 replace = "https://crim-ca.github.io/mlm-extension/v{new_version}/schema.json"
 


### PR DESCRIPTION
## Description

Remove very verbose output from over-globing when using `bump-my-version`. 

## Related Issue

- https://github.com/callowayproject/bump-my-version/issues/184

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] :books: Examples, docs, tutorials or dependencies update;
- [ ] :wrench: Bug fix (non-breaking change which fixes an issue);
- [ ] :clinking_glasses: Improvement (non-breaking change which improves an existing feature);
- [ ] :rocket: New feature (non-breaking change which adds functionality);
- [ ] :boom: Breaking change (fix or feature that would cause existing functionality to change);
- [ ] :closed_lock_with_key: Security fix.

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`CONTRIBUTING.md`](../CONTRIBUTING.md) guide;
- [x] I've updated the code style using `make codestyle`;
- [x] I've written tests for all new methods and classes that I created;
- [x] I've written the docstring in `Google` format for all the methods and classes that I used.
