### PR TITLE
Add token to publish-pypi job, fix yaml version error

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -24,13 +24,8 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2.2.2
       with:
-        python-version: 3.10
+        python-version: "3.10"
     - name: Install poetry
       run: make poetry-install
     - name: Publish to PyPI
       run: poetry publish --username __token__ --password ${{ secrets.PYPI_SECRET }}
-  print-ref:
-    runs-on: ubuntu-latest
-    steps:
-    - name: Print github.ref
-      run: echo ${{ github.ref }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -27,6 +27,10 @@ jobs:
         python-version: 3.10
     - name: Install poetry
       run: make poetry-install
-    - name: Build and publish
-      run: |
-        make publish
+    - name: Publish to PyPI
+      run: poetry publish --username __token__ --password ${{ secrets.PYPI_SECRET }}
+  print-ref:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Print github.ref
+      run: echo ${{ github.ref }}


### PR DESCRIPTION
## Description

this adds the pypi token to the publish step and wraps the python version used to build the wheel in quotes

## Related Issue

#13 

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] :books: Examples, docs, tutorials or dependencies update;
- [x] :wrench: Bug fix (non-breaking change which fixes an issue);
- [ ] :clinking_glasses: Improvement (non-breaking change which improves an existing feature);
- [ ] :rocket: New feature (non-breaking change which adds functionality);
- [ ] :boom: Breaking change (fix or feature that would cause existing functionality to change);
- [ ] :closed_lock_with_key: Security fix.

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`CONTRIBUTING.md`][2] guide;
- [ ] I've updated the code style using `make codestyle`;
- [ ] I've written tests for all new methods and classes that I created;
- [ ] I've written the docstring in `Google` format for all the methods and classes that I used.

[1]: https://github.com/rbavery/stac-model/blob/master/CODE_OF_CONDUCT.md
[2]: https://github.com/rbavery/stac-model/blob/master/CONTRIBUTING.md
