### PR TITLE
fix `stac-model` readme

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -22,6 +22,6 @@
 <!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->
 
 - [ ] I've read the [`CONTRIBUTING.md`](../CONTRIBUTING.md) guide;
-- [ ] I've updated the code style using `make codestyle`;
+- [ ] I've updated the code style using `make check`;
 - [ ] I've written tests for all new methods and classes that I created;
 - [ ] I've written the docstring in `Google` format for all the methods and classes that I used.

--- a/.safety-policy.yml
+++ b/.safety-policy.yml
@@ -1,0 +1,76 @@
+# Safety Security and License Configuration file
+# https://docs.safetycli.com/safety-docs/administration/safety-policy-files
+
+security: # configuration for the `safety check` command
+    ignore-cvss-severity-below: 0
+    ignore-cvss-unknown-severity: False
+    ignore-vulnerabilities:
+        67599:
+            reason: disputed pip feature not used by this project
+    continue-on-vulnerability-error: False
+alert: # configuration for the `safety alert` command
+    security:
+        # Configuration specific to Safety's GitHub Issue alerting
+        github-issue:
+            # Same as for security - these allow controlling if this alert will fire based
+            # on severity information.
+            # default: not set
+            # ignore-cvss-severity-below: 6
+            # ignore-cvss-unknown-severity: False
+
+            # Add a label to pull requests with the cvss severity, if available
+            # label-severity: true
+
+            # Add a label to pull requests, default is 'security'
+            # requires private repo permissions, even on public repos
+            # default: security
+            labels:
+              - security
+
+            # Assign users to pull requests, default is not set
+            # requires private repo permissions, even on public repos
+            # default: empty
+            # assignees:
+            #  - example-user
+
+            # Prefix to give issues when creating them. Note that changing
+            # this might cause duplicate issues to be created.
+            # default: "[PyUp] "
+            # issue-prefix: "[PyUp] "
+
+        # Configuration specific to Safety's GitHub PR alerting
+        github-pr:
+            # Same as for security - these allow controlling if this alert will fire based
+            # on severity information.
+            # default: not set
+            # ignore-cvss-severity-below: 6
+            # ignore-cvss-unknown-severity: False
+
+            # Set the default branch (ie, main, master)
+            # default: empty, the default branch on GitHub
+            branch: ''
+
+            # Add a label to pull requests with the cvss severity, if available
+            # default: true
+            # label-severity: True
+
+            # Add a label to pull requests, default is 'security'
+            # requires private repo permissions, even on public repos
+            # default: security
+            labels:
+              - security
+
+            # Assign users to pull requests, default is not set
+            # requires private repo permissions, even on public repos
+            # default: empty
+            # assignees:
+            #  - example-user
+
+            # Configure the branch prefix for PRs created by this alert.
+            # NB: Changing this will likely cause duplicate PRs.
+            # default: pyup/
+            branch-prefix: pyup/
+
+            # Set a global prefix for PRs
+            # default: "[PyUp] "
+            pr-prefix: "[PyUp] "

--- a/README_STAC_MODEL.md
+++ b/README_STAC_MODEL.md
@@ -80,7 +80,7 @@ See [LICENSE][blic2] for more details.
 [bp16]: https://github.com/crim-ca/mlm-extension/blob/main/.pre-commit-config.yaml
 
 [blic1]: https://img.shields.io/github/license/crim-ca/mlm-extension?style=for-the-badge
-[blic2]: https://github.com/crim-ca/mlm-extension/blob/main/LICENCE
+[blic2]: https://github.com/crim-ca/mlm-extension/blob/main/LICENSE
 [blic3]: https://img.shields.io/badge/%F0%9F%93%A6-semantic%20versions-4053D6?style=for-the-badge
 
 [github-releases]: https://github.com/crim-ca/mlm-extension/releases
@@ -92,7 +92,6 @@ See [LICENSE][blic2] for more details.
 
 [hub1]: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuring-dependabot-version-updates#enabling-dependabot-version-updates
 [hub2]: https://github.com/marketplace/actions/close-stale-issues
-[hub5]: https://github.com/crim-ca/mlm-extension/blob/main/.github/workflows/build.yml
 [hub6]: https://docs.github.com/en/code-security/dependabot
 [hub8]: https://github.com/crim-ca/mlm-extension/blob/main/.github/release-drafter.yml
 [hub9]: https://github.com/crim-ca/mlm-extension/blob/main/.github/.stale.yml

--- a/README_STAC_MODEL.md
+++ b/README_STAC_MODEL.md
@@ -67,35 +67,35 @@ See [LICENSE][blic2] for more details.
 [bp1]: https://img.shields.io/pypi/pyversions/stac-model?style=for-the-badge
 [bp2]: https://pypi.org/project/stac-model/
 [bp3]: https://img.shields.io/pypi/v/stac-model?style=for-the-badge&logo=pypi&color=3775a9
-[bp4]: https://github.com/stac-extensions/stac-model
-[bp5]: https://github.com/stac-extensions/stac-model/releases
+[bp4]: https://github.com/crim-ca/mlm-extension
+[bp5]: https://github.com/crim-ca/mlm-extension/releases
 [bp6]: https://img.shields.io/badge/made%20with-galactipy%20%F0%9F%8C%8C-179287?style=for-the-badge&labelColor=193A3E
 [bp7]: https://kutt.it/7fYqQl
 [bp8]: https://img.shields.io/static/v1.svg?label=Contributions&message=Welcome&color=0059b3&style=for-the-badge
-[bp9]: https://github.com/stac-extensions/stac-model/blob/main/CONTRIBUTING.md
+[bp9]: https://github.com/crim-ca/mlm-extension/blob/main/CONTRIBUTING.md
 [bp11]: https://img.shields.io/endpoint?url=https://python-poetry.org/badge/v0.json&style=for-the-badge
 [bp12]: https://python-poetry.org/
 
 [bp15]: https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white&style=for-the-badge
-[bp16]: https://github.com/stac-extensions/stac-model/blob/main/.pre-commit-config.yaml
+[bp16]: https://github.com/crim-ca/mlm-extension/blob/main/.pre-commit-config.yaml
 
-[blic1]: https://img.shields.io/github/license/stac-extensions/stac-model?style=for-the-badge
-[blic2]: https://github.com/stac-extensions/stac-model/blob/main/LICENCE
+[blic1]: https://img.shields.io/github/license/crim-ca/mlm-extension?style=for-the-badge
+[blic2]: https://github.com/crim-ca/mlm-extension/blob/main/LICENCE
 [blic3]: https://img.shields.io/badge/%F0%9F%93%A6-semantic%20versions-4053D6?style=for-the-badge
 
-[github-releases]: https://github.com/stac-extensions/stac-model/releases
+[github-releases]: https://github.com/crim-ca/mlm-extension/releases
 
 [bscm1]: https://img.shields.io/badge/GitHub-100000?style=for-the-badge&logo=github&logoColor=white
-[bscm2]: https://img.shields.io/github/v/release/stac-extensions/stac-model?style=for-the-badge&logo=semantic-release&color=347d39
-[bscm6]: https://img.shields.io/github/actions/workflow/status/stac-extensions/stac-model/build.yml?style=for-the-badge&logo=github
-[bscm7]: https://github.com/stac-extensions/stac-model/actions/workflows/build.yml
+[bscm2]: https://img.shields.io/github/v/release/crim-ca/mlm-extension?style=for-the-badge&logo=semantic-release&color=347d39
+[bscm6]: https://img.shields.io/github/actions/workflow/status/crim-ca/mlm-extension/build.yml?style=for-the-badge&logo=github
+[bscm7]: https://github.com/crim-ca/mlm-extension/actions/workflows/build.yml
 
 [hub1]: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuring-dependabot-version-updates#enabling-dependabot-version-updates
 [hub2]: https://github.com/marketplace/actions/close-stale-issues
-[hub5]: https://github.com/stac-extensions/stac-model/blob/main/.github/workflows/build.yml
+[hub5]: https://github.com/crim-ca/mlm-extension/blob/main/.github/workflows/build.yml
 [hub6]: https://docs.github.com/en/code-security/dependabot
-[hub8]: https://github.com/stac-extensions/stac-model/blob/main/.github/release-drafter.yml
-[hub9]: https://github.com/stac-extensions/stac-model/blob/main/.github/.stale.yml
+[hub8]: https://github.com/crim-ca/mlm-extension/blob/main/.github/release-drafter.yml
+[hub9]: https://github.com/crim-ca/mlm-extension/blob/main/.github/.stale.yml
 
 [bdoc1]: https://img.shields.io/badge/docs-github%20pages-0a507a?style=for-the-badge
-[bdoc2]: https://stac-extensions.github.io/stac-model
+[bdoc2]: https://github.com/crim-ca/mlm-extension/blob/main/README_STAC_MODEL.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,11 +9,14 @@ build-backend = "poetry.core.masonry.api"
 name = "stac-model"
 version = "0.1.3"
 description = "A PydanticV2 validation and serialization libary for the STAC ML Model Extension"
-readme = "README.md"
-authors = ["Ryan Avery <ryan@wherobots.com>"]
+readme = "README_STAC_MODEL.md"
+authors = [
+  "Ryan Avery <ryan@wherobots.com>",
+  "Francis Charette-Migneault <francis.charette-migneault@crim.ca>"
+]
 license = "Apache Software License 2.0"
-repository = "https://github.com/rbavery/stac-model"
-homepage = "https://github.com/rbavery/stac-model"
+repository = "https://github.com/crim-ca/mlm-extension"
+homepage = "https://github.com/crim-ca/mlm-extension/blob/main/README_STAC_MODEL.md"
 packages = [
   {include = "stac_model"}
 ]
@@ -25,13 +28,15 @@ keywords = []  # UPDATEME with relevant keywords
 
 # Pypi classifiers: https://pypi.org/classifiers/
 classifiers = [
-  "Development Status :: 3 - Alpha",
+  "Development Status :: 4 - Beta",
   "Operating System :: OS Independent",
   "Topic :: Software Development :: Libraries :: Python Modules",
   "License :: OSI Approved :: Apache Software License",
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3 :: Only",
   "Framework :: Pydantic",
   "Framework :: Pydantic :: 2",
   "Intended Audience :: Developers",
@@ -85,6 +90,11 @@ ruff = "^0.2.2"
 bump-my-version = "^0.21"
 
 [tool.bumpversion]
+# NOTE:
+#   Although these definitions are provided in this 'stac-model' project file,
+#   they are actually intented for versioning the MLM specification itself.
+#   To version 'stac-model', use the 'poetry version' operations.
+#   See also https://github.com/crim-ca/mlm-extension/blob/main/CONTRIBUTING.md#building-and-releasing
 current_version = "1.1.0"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]


### PR DESCRIPTION
## Description

- fix invalid links in stac-model readme 
- adjust specific readme of STAC Model for pypi 

Rather than modifying all the links in https://github.com/crim-ca/mlm-extension/blob/main/README.md to use full URLs (see #15), the PyPI package distribution is modified to point at https://github.com/crim-ca/mlm-extension/blob/main/README_STAC_MODEL.md

Doing so, the corresponding links inside that `README_STAC_MODEL.md` are adjusted as expected.

## Related Issue

- fixes #15 

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] :books: Examples, docs, tutorials or dependencies update;
- [x] :wrench: Bug fix (non-breaking change which fixes an issue);
- [ ] :clinking_glasses: Improvement (non-breaking change which improves an existing feature);
- [ ] :rocket: New feature (non-breaking change which adds functionality);
- [ ] :boom: Breaking change (fix or feature that would cause existing functionality to change);
- [ ] :closed_lock_with_key: Security fix.

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`CONTRIBUTING.md`](../CONTRIBUTING.md) guide;
- [x] I've updated the code style using `make codestyle`;
- [ ] I've written tests for all new methods and classes that I created;
- [ ] I've written the docstring in `Google` format for all the methods and classes that I used.
