### PR TITLE
remove example fixme notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,9 +78,6 @@ For more details about the [`stac-model`](./stac_model) Python package, which pr
 using both [`Pydantic`](https://docs.pydantic.dev/latest/) and [`PySTAC`](https://pystac.readthedocs.io/en/stable/)
 connectors, please refer to the [STAC Model](./README_STAC_MODEL.md) document.
 
-> :warning: <br>
-> FIXME: update examples
-
 - Examples:
   - [Item examples](https://huggingface.co/wherobots/mlm-stac) for scene-classification,
       object detection, and semantic segmentation: Shows real world use of the


### PR DESCRIPTION
## Description

I missed removing the fix me notice on the last PR, now that we have more examples for items, no need for the fix me notice.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] :books: Examples, docs, tutorials or dependencies update;
- [ ] :wrench: Bug fix (non-breaking change which fixes an issue);
- [ ] :clinking_glasses: Improvement (non-breaking change which improves an existing feature);
- [ ] :rocket: New feature (non-breaking change which adds functionality);
- [ ] :boom: Breaking change (fix or feature that would cause existing functionality to change);
- [ ] :closed_lock_with_key: Security fix.

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've read the [`CONTRIBUTING.md`](../CONTRIBUTING.md) guide;
- [ ] I've updated the code style using `make check`;
- [ ] I've written tests for all new methods and classes that I created;
- [ ] I've written the docstring in `Google` format for all the methods and classes that I used.
