### PR TITLE
Deprecate crim-ca/mlm-extension in favor of stac-extensions/mlm

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,16 @@
 # Machine Learning Model Extension Specification
 
+> :warning: <br>
+> This repository is deprecated in favor of the new official community location
+> [stac-extensions/mlm](https://github.com/stac-extensions/mlm). <br>
+> The corresponding schemas are made available on
+> [https://stac-extensions.github.io/mlm/](https://stac-extensions.github.io/mlm/).
+>
+> This repository remains availabe as archive for STAC definitions that could still refer to
+> [https://crim-ca.github.io/mlm-extension/](https://crim-ca.github.io/mlm-extension/) schemas.
+> If you intend to employ STAC MLM for future work, it is **STRONGLY** recommended that you migrate to the
+> [stac-extensions/mlm](https://github.com/stac-extensions/mlm) schemas.
+
 [![hackmd-github-sync-badge](https://hackmd.io/N1cWyDM2S9eaAQtSvS0J_A/badge)](https://hackmd.io/N1cWyDM2S9eaAQtSvS0J_A?both)
 
 - **Title:** Machine Learning Model Extension


### PR DESCRIPTION
## Description

Update README with redirect message.

## Related Issue

- Details: https://github.com/orgs/stac-utils/discussions/4#discussioncomment-10767685

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] :books: Examples, docs, tutorials or dependencies update;
- [ ] :wrench: Bug fix (non-breaking change which fixes an issue);
- [ ] :clinking_glasses: Improvement (non-breaking change which improves an existing feature);
- [ ] :rocket: New feature (non-breaking change which adds functionality);
- [ ] :boom: Breaking change (fix or feature that would cause existing functionality to change);
- [ ] :closed_lock_with_key: Security fix.

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've read the [`CONTRIBUTING.md`](../CONTRIBUTING.md) guide;
- [ ] I've updated the code style using `make check`;
- [ ] I've written tests for all new methods and classes that I created;
- [ ] I've written the docstring in `Google` format for all the methods and classes that I used.
